### PR TITLE
[Dist/Tizen] Add rpm spec and manifest files for GBS/OBS build

### DIFF
--- a/packaging/libtbb.manifest
+++ b/packaging/libtbb.manifest
@@ -1,0 +1,5 @@
+<manifest>
+	<request>
+		<domain name="_"/>
+	</request>
+</manifest>

--- a/packaging/libtbb.pc.in
+++ b/packaging/libtbb.pc.in
@@ -1,0 +1,10 @@
+prefix=@PREFIX@
+libdir=@LIB_INSTALL_DIR@
+includedir=@INCLUDE_INSTALL_DIR@
+
+Name: libtbb
+Description: Development package to use Intel® Threading Building Blocks
+Version: @VERSION@
+Requires:
+Libs: -L${libdir} -ltbb
+Cflags: -I${includedir}/tbb

--- a/packaging/libtbb.spec
+++ b/packaging/libtbb.spec
@@ -1,0 +1,64 @@
+Name:       libtbb
+Summary:    Intel® Threading Building Blocks
+Version:    2019U3
+Release:    0
+Group:      Development/Libraries
+Packager:   Wook Song <wook16.song@samsung.com>
+License:    Apache-2.0
+Source0:    %{name}-%{version}.tar.gz
+Source1:    %{name}.manifest
+Source1001:    %{name}.pc.in
+
+%description
+Threading Building Blocks (TBB) lets you easily write parallel C++ programs
+that take full advantage of multicore performance, that are portable,
+composable and have future-proof scalability.
+
+%package devel
+License: Apache-2.0
+Summary: Development package to use Intel® Threading Building Blocks
+Group: Development/Libraries
+Requires: %{name} = %{version}-%{release}
+
+%description devel
+This package provides headers and other miscellaneous files required to use Intel® TBB.
+
+%prep
+%setup -q
+cp %{SOURCE1} .
+cp %{SOURCE1001} .
+
+%build
+%{__make} tbb_build_prefix=tizen_%{_arch} %{?_smp_mflags}
+sed -i 's|@PREFIX@|%{_prefix}|g' %{name}.pc.in
+sed -i 's|@LIB_INSTALL_DIR@|%{_libdir}|g' %{name}.pc.in
+sed -i 's|@INCLUDE_INSTALL_DIR@|%{_includedir}|g' %{name}.pc.in
+
+%install
+pushd build/tizen_%{_arch}_release
+mkdir -p %{buildroot}%{_libdir}
+install -m 644 *.so* %{buildroot}%{_libdir}
+popd
+mkdir -p %{buildroot}%{_includedir}
+cp -rf include/tbb %{buildroot}%{_includedir}/
+mkdir -p %{buildroot}%{_libdir}/pkgconfig
+install -m 644 %{name}.pc.in %{buildroot}%{_libdir}/pkgconfig/%{name}.pc
+
+%post
+%{_sbindir}/ldconfig
+
+%postun
+%{_sbindir}/ldconfig
+
+%files
+%manifest %{name}.manifest
+%license LICENSE
+%{_libdir}/lib*.so.*
+
+
+%files devel
+%manifest %{name}.manifest
+%license LICENSE
+%{_libdir}/lib*.so
+%{_libdir}/pkgconfig/*.pc
+%{_includedir}/*


### PR DESCRIPTION
For the purpose of resolving build-dependencies of OpenVino, this patch adds rpm spec and manifest files for Tizen GBS/OBS build support.

See also: https://github.com/nnsuite/nnstreamer/issues/1708

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped